### PR TITLE
feat: allow turning the "strict mode" off

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Enable strict mode. It will filter out sentences that are fuzzily similar to one of RESTRICTED_WORDS.
+# Example: "h@ck", "h a c k" or "h-a-c-k" will also be banned.
+#
+# Set to "off" to disable strict mode, which will only filter out sentences that are EXACTLY THE SAME AS one of RESTRICTED_WORDS (above examples will be accepted).
+# 
+# Note: Turning off strict mode won't disable the offensive/abusive language filter. This filter is always enabled.
+#
+# Other values will be considered as enabled (including falsy value).
+# Default: on
+ENGINE_STRICT_MODE=
+RESTRICTED_WORDS="hack,hacking,scam,scamming,cheat,cheating,plagiarism,stupid"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "deno.enable": true
+  "deno.enable": true
 }

--- a/README.md
+++ b/README.md
@@ -7,24 +7,39 @@ adhering to advanced safety guidelines to prevent disallowed content from being 
 generated.
 </p>
 
-<sup>Built with <img src="https://deno.land/logo.svg" height="15px" alt="the deno mascot dinosaur standing in the rain"> Deno</sup>
+<sup>Built with
+<img src="https://deno.land/logo.svg" height="15px" alt="the deno mascot dinosaur standing in the rain">
+Deno</sup>
 
 </div>
 
 ## Don't wanna setup anything?
 
-If you use MacOS (ARM64), run the pre-compiled standalone executable file inside [exec folder](./exec/).
+If you use MmacOS (ARM64), run the pre-compiled standalone executable file
+inside [exec folder](./exec/).
 
-## Environment
+## Development
 
-Please ensure your device has Deno installed. If not, follow [the official guide](https://docs.deno.com/runtime/getting_started/installation/) for a quick installation.
+### Runtime
 
-## Local development
+Please ensure your device has [Deno](https://deno.land/) installed. If not,
+follow
+[the official guide](https://docs.deno.com/runtime/getting_started/installation/)
+for a quick installation.
 
 ### Setting up your editor/IDE
 
-- VSCode: Install the official [Deno extension](https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno).
-- Other editor/IDE: please follow the [setup your environment](https://docs.deno.com/runtime/getting_started/setup_your_environment/#setting-up-your-editor%2Fide) guide.
+- VSCode: Install the official
+  [Deno extension](https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno).
+- Other editor/IDE: please follow the
+  [setup your environment](https://docs.deno.com/runtime/getting_started/setup_your_environment/#setting-up-your-editor%2Fide)
+  guide.
+
+### Environment variables
+
+```console
+cp .env.example .env
+```
 
 ### Dev server
 
@@ -49,7 +64,13 @@ deno lint
 ### Test
 
 ```console
-deno test
+deno run test
+```
+
+OR
+
+```console
+deno test --allow-env
 ```
 
 ## Compile standalone executables

--- a/constants.ts
+++ b/constants.ts
@@ -1,15 +1,12 @@
+import "@std/dotenv/load";
 export const LOG_FILE = "chatbot_log.txt";
 
-export const RESTRICTED_WORDS = [
-  "hack",
-  "hacking",
-  "scam",
-  "scamming",
-  "cheat",
-  "cheating",
-  "plagiarism",
-  "stupid",
-];
+export const ENGINE = {
+  STRICT_MODE: Deno.env.get("ENGINE_STRICT_MODE") === "off" ? false : true,
+};
+
+export const RESTRICTED_WORDS = Deno.env.get("RESTRICTED_WORDS")?.split(",") ||
+  [];
 
 export const RESTRICTED_FALLBACK =
   "I'm sorry, but I can't assist with that request.";

--- a/deno.json
+++ b/deno.json
@@ -1,12 +1,14 @@
 {
   "tasks": {
-    "dev": "deno run --allow-write main.ts",
-    "compile": "deno compile --allow-write --output exec/chatbot --target aarch64-apple-darwin main.ts",
-    "compile:window": "deno compile --allow-write --output exec/chatbot-window --target x86_64-pc-windows-msvc main.ts"
+    "dev": "deno run -R -W --allow-env main.ts",
+    "test": "deno test -R --allow-env",
+    "compile": "deno compile -R -W --allow-env --env --output exec/chatbot --target aarch64-apple-darwin main.ts",
+    "compile:window": "deno compile -R -W --allow-env --env --output exec/chatbot-window --target x86_64-pc-windows-msvc main.ts"
   },
   "imports": {
     "@2toad/profanity": "npm:@2toad/profanity@^3.0.1",
     "@std/assert": "jsr:@std/assert@1",
+    "@std/dotenv": "jsr:@std/dotenv@^0.225.2",
     "fuse.js": "npm:fuse.js@^7.0.0"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@std/assert@1": "1.0.8",
     "jsr:@std/assert@^1.0.8": "1.0.8",
+    "jsr:@std/dotenv@~0.225.2": "0.225.2",
     "jsr:@std/internal@^1.0.5": "1.0.5",
     "npm:@2toad/profanity@*": "3.0.1",
     "npm:@2toad/profanity@^3.0.1": "3.0.1",
@@ -15,6 +16,9 @@
       "dependencies": [
         "jsr:@std/internal"
       ]
+    },
+    "@std/dotenv@0.225.2": {
+      "integrity": "e2025dce4de6c7bca21dece8baddd4262b09d5187217e231b033e088e0c4dd23"
     },
     "@std/internal@1.0.5": {
       "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
@@ -41,6 +45,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@1",
+      "jsr:@std/dotenv@~0.225.2",
       "npm:@2toad/profanity@^3.0.1",
       "npm:fuse.js@7"
     ]

--- a/engine.test.ts
+++ b/engine.test.ts
@@ -1,7 +1,8 @@
 import { assertEquals } from "@std/assert";
-import { sanitizedContent, processCommand } from "./engine.ts";
+import { processCommand, sanitizedContent } from "./engine.ts";
 import {
   CHATBOT_ID,
+  ENGINE,
   RESPONSE_PREFIX,
   RESTRICTED_FALLBACK,
 } from "./constants.ts";
@@ -9,6 +10,11 @@ import {
 Deno.test(
   "[engine] sanitizedContent function should return restricted fallback for restricted words",
   () => {
+    // Always enable strict mode for this test
+    if (!ENGINE.STRICT_MODE) {
+      ENGINE.STRICT_MODE = true;
+    }
+
     const inputs = [
       "You're stupid",
       "How to hack into an office network?",
@@ -21,7 +27,7 @@ Deno.test(
       const result = sanitizedContent(input);
       assertEquals(result, `${CHATBOT_ID}: ${RESTRICTED_FALLBACK}`);
     });
-  }
+  },
 );
 
 Deno.test(
@@ -30,7 +36,7 @@ Deno.test(
     const content = "Hello world";
     const result = sanitizedContent(content);
     assertEquals(result, `${CHATBOT_ID}: ${RESPONSE_PREFIX} ${content}`);
-  }
+  },
 );
 
 Deno.test("[engine] processCommand should handle exit command", () => {

--- a/main.ts
+++ b/main.ts
@@ -1,8 +1,21 @@
+import { ENGINE, RESTRICTED_WORDS } from "./constants.ts";
 import { processCommand, sanitizedContent } from "./engine.ts";
-import { getRandomUserId, printHelp, logging } from "./utils.ts";
+import { getRandomUserId, logging, printHelp } from "./utils.ts";
+
+function greeting() {
+  if (ENGINE.STRICT_MODE) {
+    console.log("\x1b[42m\x1b[37m%s\x1b[0m", "strict mode");
+  } else {
+    console.log("\x1b[43m\x1b[37m%s\x1b[0m", "strict mode is off");
+  }
+
+  console.log("\nWelcome to SafeChat!\n---------------------");
+}
 
 function main() {
-  console.log("Welcome to SafeChat!\n---------------------");
+  console.log("Restricted words:", RESTRICTED_WORDS);
+
+  greeting();
   printHelp();
 
   const userId = getRandomUserId();

--- a/utils.test.ts
+++ b/utils.test.ts
@@ -7,7 +7,8 @@ Deno.test("[utils] logging function should write correct log message", () => {
   const message = "Hello",
     botResponse = message;
   const timestamp = new Date().toISOString();
-  const expectedLogMessage = `[${timestamp}] ${userId}: ${message}\n[${timestamp}] Bot: ${botResponse}\n`;
+  const expectedLogMessage =
+    `[${timestamp}] ${userId}: ${message}\n[${timestamp}] Bot: ${botResponse}\n`;
 
   let writtenLogMessage = "";
   const originalWriteTextFileSync = Deno.writeTextFileSync;

--- a/utils.ts
+++ b/utils.ts
@@ -1,14 +1,15 @@
 import { LOG_FILE } from "./constants.ts";
 
 export function getRandomUserId(): string {
-  return `user-${(Math.random() * 100) | 0}`;
+  return `user-${(Math.random() * 1000) | 0}`;
 }
 
 export function printHelp() {
   console.log(`\nCommands:
-    - exit, quit, :q  Exit the program
-    - clear, cls      Clear the chat history
-    - help, :h        Show this help
+    - strict-mode, :sm  Toggle the strict mode
+    - exit, quit, :q    Exit the program
+    - clear, cls        Clear the chat history
+    - help, :h          Show this help
     `);
 }
 
@@ -25,7 +26,8 @@ export function logging({
   botResponse,
   timestamp = new Date().toISOString(),
 }: Logging) {
-  const logMessage = `[${timestamp}] ${userId}: ${message}\n[${timestamp}] Bot: ${botResponse}\n`;
+  const logMessage =
+    `[${timestamp}] ${userId}: ${message}\n[${timestamp}] Bot: ${botResponse}\n`;
   Deno.writeTextFileSync(LOG_FILE, logMessage, { append: true });
 }
 


### PR DESCRIPTION
Now allow to turn the "strict mode" off.

> Strict mode: Filter out sentences that are fuzzily similar to one of RESTRICTED_WORDS.

Example: "h@ck", "h a c k" or "h-a-c-k" will also be banned.

Set to `"off"` to disable strict mode, which will only filter out sentences that are EXACTLY THE SAME AS one of RESTRICTED_WORDS (above examples will be accepted).
_Note_: Turning off strict mode won't disable the offensive/abusive language filter. This filter is always enabled.

Other values will be considered as enabled (including falsy value).
**Default value**: `"on"`